### PR TITLE
fix: Fix build.sh failed if multiple sockets/files in a single directory.

### DIFF
--- a/build/bridge.sh
+++ b/build/bridge.sh
@@ -23,11 +23,11 @@ TEMP_PATH=${TEMP_PATH:-"$TMPDIR"}
 
 VESSEL_PATH="$BRIDGE_PATH"
 IPC_PATHS="$TEMP_PATH /run/user/$(id -u) $TEMP_PATH/app/com.discordapp.Discord $TEMP_PATH/.flatpak/dev.vencord.Vesktop/xdg-run $TEMP_PATH/snap.discord $TEMP_PATH/snap.discord-canary"
-for discord_ipc in $IPC_PATHS; do
-	if [ -S "$discord_ipc"/discord-ipc-? ]; then
-		VESSEL_PATH="$BRIDGE_PATH:$(echo "$discord_ipc"/discord-ipc-?)"
-		break
-	fi
-done
+
+# shellcheck disable=2086
+socket=$(find $IPC_PATHS -mindepth 1 -maxdepth 1 -type s -name 'discord-ipc-*' 2>/dev/null|head -n 1)
+if [ -S "$socket" ]; then
+    VESSEL_PATH="$BRIDGE_PATH:$socket"
+fi
 
 PROTON_REMOTE_DEBUG_CMD="$BRIDGE_CMD" PRESSURE_VESSEL_FILESYSTEMS_RW="$VESSEL_PATH:$PRESSURE_VESSEL_FILESYSTEMS_RW" "$@"

--- a/build/bridge.sh
+++ b/build/bridge.sh
@@ -22,7 +22,7 @@ TEMP_PATH="$XDG_RUNTIME_DIR"
 TEMP_PATH=${TEMP_PATH:-"$TMPDIR"}
 
 VESSEL_PATH="$BRIDGE_PATH"
-IPC_PATHS="$TEMP_PATH /run/user/$(id -u) $TEMP_PATH/app/com.discordapp.Discord $TEMP_PATH/.flatpak/dev.vencord.Vesktop/xdg-run $TEMP_PATH/snap.discord $TEMP_PATH/snap.discord-canary"
+IPC_PATHS="$TEMP_PATH /run/user/$(id -u) $TEMP_PATH/app/com.discordapp.Discord $TEMP_PATH/.flatpak/dev.vencord.Vesktop/xdg-run $TEMP_PATH/snap.discord $TEMP_PATH/snap.discord-canary $TEMP_PATH/app/com.discordapp.DiscordCanary"
 
 # shellcheck disable=2086
 for socket in $(find $IPC_PATHS -mindepth 1 -maxdepth 1 \( -type s -o -type f \) -name 'discord-ipc-*' 2>/dev/null); do

--- a/build/bridge.sh
+++ b/build/bridge.sh
@@ -25,9 +25,11 @@ VESSEL_PATH="$BRIDGE_PATH"
 IPC_PATHS="$TEMP_PATH /run/user/$(id -u) $TEMP_PATH/app/com.discordapp.Discord $TEMP_PATH/.flatpak/dev.vencord.Vesktop/xdg-run $TEMP_PATH/snap.discord $TEMP_PATH/snap.discord-canary"
 
 # shellcheck disable=2086
-socket=$(find $IPC_PATHS -mindepth 1 -maxdepth 1 -type s -name 'discord-ipc-*' 2>/dev/null|head -n 1)
-if [ -S "$socket" ]; then
-    VESSEL_PATH="$BRIDGE_PATH:$socket"
-fi
+for socket in $(find $IPC_PATHS -mindepth 1 -maxdepth 1 \( -type s -o -type f \) -name 'discord-ipc-*' 2>/dev/null); do
+    case ":$VESSEL_PATH:" in
+        *":$socket:"*) ;;
+        *) { [ -S "$socket" ] || [ -f "$socket" ]; } && VESSEL_PATH="$VESSEL_PATH:$socket" ;;
+    esac
+done
 
 PROTON_REMOTE_DEBUG_CMD="$BRIDGE_CMD" PRESSURE_VESSEL_FILESYSTEMS_RW="$VESSEL_PATH:$PRESSURE_VESSEL_FILESYSTEMS_RW" "$@"

--- a/build/bridge.sh
+++ b/build/bridge.sh
@@ -6,7 +6,8 @@
 # As requested by https://github.com/EnderIce2/rpc-bridge/issues/2
 
 # Exporting BRIDGE_PATH to provide the bridge with its location.
-export BRIDGE_PATH="$(dirname "$0")/bridge.exe"
+BRIDGE_PATH="$(dirname "$0")/bridge.exe"
+export BRIDGE_PATH
 
 #  The "--steam" option prevents the game from
 # hanging as "running" in Steam after it is closed.
@@ -21,7 +22,7 @@ TEMP_PATH="$XDG_RUNTIME_DIR"
 TEMP_PATH=${TEMP_PATH:-"$TMPDIR"}
 
 VESSEL_PATH="$BRIDGE_PATH"
-IPC_PATHS="$TEMP_PATH /run/user/$UID $TEMP_PATH/app/com.discordapp.Discord $TEMP_PATH/.flatpak/dev.vencord.Vesktop/xdg-run $TEMP_PATH/snap.discord $TEMP_PATH/snap.discord-canary"
+IPC_PATHS="$TEMP_PATH /run/user/$(id -u) $TEMP_PATH/app/com.discordapp.Discord $TEMP_PATH/.flatpak/dev.vencord.Vesktop/xdg-run $TEMP_PATH/snap.discord $TEMP_PATH/snap.discord-canary"
 for discord_ipc in $IPC_PATHS; do
 	if [ -S "$discord_ipc"/discord-ipc-? ]; then
 		VESSEL_PATH="$BRIDGE_PATH:$(echo "$discord_ipc"/discord-ipc-?)"


### PR DESCRIPTION
If there are multiple files in a single directory that match discord ipc sockets name (Can be files or symlinks).  
The scripts will failed to find any socket in that directory with the error

```
./bridge.sh: line 26: [: too many arguments
./bridge.sh: line 26: [: too many arguments
```

The first commit fix some warning with shellcheck

[SC2155 (warning): Declare and assign separately to avoid masking return values.](https://www.shellcheck.net/wiki/SC2155)  
[SC3028 (warning): In POSIX sh, UID is undefined.](https://www.shellcheck.net/wiki/SC3028)  
[SC2144 (error): -S doesn't work with globs. Use a for loop.](https://www.shellcheck.net/wiki/SC2144)
