### PR TITLE
minor qol to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Logs are stored in `C:\windows\logs\bridge.log`.
 ##### Steam
 
 - Right click on the game and select `Properties`.
-- Under `Set Launch Options`, add the following:
+- Under `Set Launch Options`, add the following: `/path/to/bridge.sh %command%`
     - ![bridge.sh](docs/assets/steam_script.png "Set Launch Options to the path of the bridge.sh")
 - The `bridge.sh` script must be in the same directory as `bridge.exe`.
 


### PR DESCRIPTION
minor change so you can copy and paste the command instead of having to manually type in the launch options from the image